### PR TITLE
Get history

### DIFF
--- a/src/pages/Homepage.js
+++ b/src/pages/Homepage.js
@@ -32,7 +32,11 @@ export default function Homepage() {
         <ListItem>For SOS helpline dial: 0900 0767</ListItem>
         <ListItem>For ChildLine dial: 0800 0432</ListItem>
       </List>
-      <Button onClick={() => history.push("/form")}>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={() => history.push("/form")}
+      >
         Go to Evaluation Form
       </Button>
     </Box>

--- a/src/pages/ResultsPage.js
+++ b/src/pages/ResultsPage.js
@@ -3,6 +3,8 @@ import { useSelector } from "react-redux";
 
 import { selectSentiment } from "../store/sentiment/selectors";
 
+import { Button } from "@material-ui/core";
+
 export default function ResultsPage() {
   const sentimentScore = useSelector(selectSentiment());
   console.log(sentimentScore);
@@ -10,6 +12,9 @@ export default function ResultsPage() {
     <div>
       <h1>Results</h1>
       <h1>{sentimentScore}</h1>
+      <Button variant="contained" color="primary">
+        See History
+      </Button>
     </div>
   );
 }

--- a/src/pages/ResultsPage.js
+++ b/src/pages/ResultsPage.js
@@ -15,7 +15,6 @@ export default function ResultsPage() {
   }
 
   const history = useSelector(selectHistory());
-
   console.log(history);
 
   const sentimentScore = useSelector(selectSentiment());
@@ -26,6 +25,11 @@ export default function ResultsPage() {
       <Button variant="contained" color="primary" onClick={getHistory}>
         See History
       </Button>
+      {history
+        ? history.map((i) => {
+            return <p key={i.id}>{i.score}</p>;
+          })
+        : null}
     </div>
   );
 }

--- a/src/pages/ResultsPage.js
+++ b/src/pages/ResultsPage.js
@@ -1,18 +1,24 @@
 import React from "react";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 
 import { selectSentiment } from "../store/sentiment/selectors";
+import { getSentimentHistoryThunkCreator } from "../store/sentiment/actions";
 
 import { Button } from "@material-ui/core";
 
 export default function ResultsPage() {
+  const dispatch = useDispatch();
+
+  function getHistory(event) {
+    event.preventDefault();
+  }
+
   const sentimentScore = useSelector(selectSentiment());
-  console.log(sentimentScore);
   return (
     <div>
       <h1>Results</h1>
       <h1>{sentimentScore}</h1>
-      <Button variant="contained" color="primary">
+      <Button variant="contained" color="primary" onClick={getHistory}>
         See History
       </Button>
     </div>

--- a/src/pages/ResultsPage.js
+++ b/src/pages/ResultsPage.js
@@ -11,6 +11,7 @@ export default function ResultsPage() {
 
   function getHistory(event) {
     event.preventDefault();
+    dispatch(getSentimentHistoryThunkCreator());
   }
 
   const sentimentScore = useSelector(selectSentiment());

--- a/src/pages/ResultsPage.js
+++ b/src/pages/ResultsPage.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { useSelector, useDispatch } from "react-redux";
 
-import { selectSentiment } from "../store/sentiment/selectors";
+import { selectSentiment, selectHistory } from "../store/sentiment/selectors";
 import { getSentimentHistoryThunkCreator } from "../store/sentiment/actions";
 
 import { Button } from "@material-ui/core";
@@ -13,6 +13,10 @@ export default function ResultsPage() {
     event.preventDefault();
     dispatch(getSentimentHistoryThunkCreator());
   }
+
+  const history = useSelector(selectHistory());
+
+  console.log(history);
 
   const sentimentScore = useSelector(selectSentiment());
   return (

--- a/src/store/sentiment/actions.js
+++ b/src/store/sentiment/actions.js
@@ -7,6 +7,19 @@ export function scoreCalculated(score) {
   };
 }
 
+export function getSentimentHistoryThunkCreator() {
+  return async function getSentimentHistory(dispatch, getState) {
+    const sentimentHistory = await axios.get(
+      "http://localhost:4000/sentiment",
+      {
+        headers: {
+          Authorization: `Bearer ${getState().auth.accessToken}`,
+        },
+      }
+    );
+  };
+}
+
 export function sendSentimentTextThunkCreator(today, tomorrow, life) {
   return async function sendSentimentText(dispatch, getState) {
     const sentimentScore = await axios.post(

--- a/src/store/sentiment/actions.js
+++ b/src/store/sentiment/actions.js
@@ -7,6 +7,13 @@ export function scoreCalculated(score) {
   };
 }
 
+export function getHistory(history) {
+  return {
+    type: "GET_HISTORY",
+    payload: history,
+  };
+}
+
 export function getSentimentHistoryThunkCreator() {
   return async function getSentimentHistory(dispatch, getState) {
     const sentimentHistory = await axios.get(
@@ -17,7 +24,7 @@ export function getSentimentHistoryThunkCreator() {
         },
       }
     );
-    console.log(sentimentHistory.data);
+    dispatch(getHistory(sentimentHistory));
   };
 }
 

--- a/src/store/sentiment/actions.js
+++ b/src/store/sentiment/actions.js
@@ -17,6 +17,7 @@ export function getSentimentHistoryThunkCreator() {
         },
       }
     );
+    console.log(sentimentHistory.data);
   };
 }
 

--- a/src/store/sentiment/actions.js
+++ b/src/store/sentiment/actions.js
@@ -24,7 +24,7 @@ export function getSentimentHistoryThunkCreator() {
         },
       }
     );
-    dispatch(getHistory(sentimentHistory));
+    dispatch(getHistory(sentimentHistory.data));
   };
 }
 

--- a/src/store/sentiment/reducer.js
+++ b/src/store/sentiment/reducer.js
@@ -5,7 +5,7 @@ export default function sentimentReducer(state = intialState, action) {
     case "NEW_SCORE":
       return { ...state, score: action.payload };
     case "GET_HISTORY":
-      return { ...state, history: action.payload };
+      return { ...state, history: [...action.payload] };
     default:
       return state;
   }

--- a/src/store/sentiment/reducer.js
+++ b/src/store/sentiment/reducer.js
@@ -1,9 +1,11 @@
-const intialState = { score: null };
+const intialState = { history: [], score: null };
 
 export default function sentimentReducer(state = intialState, action) {
   switch (action.type) {
     case "NEW_SCORE":
       return { ...state, score: action.payload };
+    case "GET_HISTORY":
+      return { ...state, history: action.payload };
     default:
       return state;
   }

--- a/src/store/sentiment/selectors.js
+++ b/src/store/sentiment/selectors.js
@@ -3,3 +3,9 @@ export function selectSentiment() {
     return state.sentiment.score;
   };
 }
+
+export function selectHistory() {
+  return (state) => {
+    return state.sentiment.history;
+  };
+}


### PR DESCRIPTION
Added a fetch for user's sentiment history.
- Add action thunk creator to fetch history from /sentiment get endpoint.
- Add to sentiment store and selector.
- display the selected score from the fetched history array.

Small styling for buttons.