### PR TITLE
Custom form input with speech-to-text feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11127,6 +11127,11 @@
         }
       }
     },
+    "react-speech-kit": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-speech-kit/-/react-speech-kit-3.0.0.tgz",
+      "integrity": "sha512-xnnWXcTWf7Bcy/KoIncmOZ4fwprhHPhX6wjBo+GJSJ+XRKZDI96JG/8wxYYkYBPgVgmRxMSyd0Dywic3vA3AQA=="
+    },
     "react-speech-recognition": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/react-speech-recognition/-/react-speech-recognition-2.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1",
+    "react-speech-kit": "^3.0.0",
     "react-speech-recognition": "^2.1.4",
     "recharts": "^1.8.5",
     "redux": "^4.0.5",

--- a/src/components/FormInputSpeech.js
+++ b/src/components/FormInputSpeech.js
@@ -11,7 +11,6 @@ import MicIcon from "@material-ui/icons/Mic";
 import MicOffIcon from "@material-ui/icons/MicOff";
 
 export default function FormInputSpeech(props) {
-  const [open, setOpen] = useState(true);
   const buffer = useRef("");
   const { listen, listening, stop, supported } = useSpeechRecognition({
     onResult: (result) => {

--- a/src/components/FormInputSpeech.js
+++ b/src/components/FormInputSpeech.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useRef } from "react";
 import { useSpeechRecognition } from "react-speech-kit";
 
 import FormControl from "@material-ui/core/FormControl";

--- a/src/components/FormInputSpeech.js
+++ b/src/components/FormInputSpeech.js
@@ -1,0 +1,75 @@
+import React, { useState, useEffect, useRef } from "react";
+import { useSpeechRecognition } from "react-speech-kit";
+
+import FormControl from "@material-ui/core/FormControl";
+import Tooltip from "@material-ui/core/Tooltip";
+import FilledInput from "@material-ui/core/FilledInput";
+import InputLabel from "@material-ui/core/InputLabel";
+import InputAdornment from "@material-ui/core/InputAdornment";
+import IconButton from "@material-ui/core/IconButton";
+import MicIcon from "@material-ui/icons/Mic";
+import MicOffIcon from "@material-ui/icons/MicOff";
+
+export default function FormInputSpeech(props) {
+  const [open, setOpen] = useState(true);
+  const buffer = useRef("");
+  const { listen, listening, stop, supported } = useSpeechRecognition({
+    onResult: (result) => {
+      buffer.current = result;
+    },
+  });
+
+  const handleChange = (prop) => (event) => {
+    props.setValues({
+      ...props.values,
+      [props.name]: event.target.value,
+    });
+  };
+
+  const handleMic = (ref, prop) => () => {
+    props.setMics({
+      ...props.initialMics,
+      [props.name]: !props.mics[props.name],
+    });
+    if (listening) {
+      //delay stop recording for 250ms to also pick up end of sentence
+      setTimeout(() => {
+        stop();
+        props.setValues({ ...props.values, [props.name]: buffer.current });
+        buffer.current = "";
+      }, 250);
+    } else {
+      listen();
+    }
+  };
+
+  return (
+    <div>
+      <FormControl>
+        <InputLabel htmlFor={props.name}>What did you do today?</InputLabel>
+        <FilledInput
+          id={props.name}
+          type="text"
+          value={props.values[props.name]}
+          onChange={handleChange(props.name)}
+          endAdornment={
+            supported ? (
+              <Tooltip title="Keep pressed and speak" placement="right-end">
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label="toggle-mic"
+                    onMouseDown={handleMic(props.name)}
+                    onMouseUp={handleMic(props.name)}
+                    edge="end"
+                  >
+                    {props.mics[props.name] ? <MicIcon /> : <MicOffIcon />}
+                  </IconButton>
+                </InputAdornment>
+              </Tooltip>
+            ) : null
+          }
+        ></FilledInput>
+      </FormControl>
+    </div>
+  );
+}


### PR DESCRIPTION
## FormInputSpeech Component

- the component is used to render a text field with a **microphone icon**
- the mic icon will _only be displayed_ if the browser supports Web Speech API
- keeping the mic icon pressed enables the user to **use speech to text to fill out the form fields**
- to improve user experience, _recording is delayed_ (250 ms) upon releasing the mic icon to also pick up the end of the user's speech input